### PR TITLE
reducing HTTPS related warnings

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Exo+2:500);
+@import url(https://fonts.googleapis.com/css?family=Exo+2:500);
  body {
     padding-top: 40px;
     font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif;


### PR DESCRIPTION
Newer browser versions block HTTP content within HTTPS pages and issue an additional warning.